### PR TITLE
Fix Hitboxes

### DIFF
--- a/src/sdk/common/world/actor/Actor.cpp
+++ b/src/sdk/common/world/actor/Actor.cpp
@@ -136,7 +136,7 @@ float SDK::Actor::getSaturation() {
 
 bool SDK::Actor::isInvisible() {
 	// @dump-wbds Actor, isInvisible
-	return memory::callVirtual<bool>(this, SDK::mvGetOffset<0x20, 0x22, 0x25, 0x34, 0x3B, 0x3D>());
+	return memory::callVirtual<bool>(this, SDK::mvGetOffset<0x1F, 0x1F, 0x1F, 0x20, 0x20, 0x20, 0x20, 0x22, 0x25, 0x34, 0x3B, 0x3D>());
 }
 
 SDK::ItemStack* SDK::Actor::getArmor(int armorSlot) {


### PR DESCRIPTION
Fixes Hitboxes not working on some servers (e.g. Zeqa) due to wrong Actor::isInvisible vtable index