### PR TITLE
Fix stringToBuffer output

### DIFF
--- a/src/client/script/js/latiteapi.js
+++ b/src/client/script/js/latiteapi.js
@@ -141,11 +141,8 @@ util = {
         return str;
     },
     stringToBuffer: function (str) {
-        let buf = new Uint8Array(str.length);
-        for (let i = 0; i < str.length; ++i) {
-            buf[i] = str.charCodeAt(i);
-        }
-        return buf;
+        let arr = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (s, a) => String.fromCharCode('0x' + a)).split('');
+        return new Uint8Array(arr.map(c => c.charCodeAt(0)));
     }
 };
 


### PR DESCRIPTION
Fixed an issue where using filesystem to write the Uint8Array returned from util.stringToBuffer causing characters like § and » to become �
