### PR TITLE
Fix DX11 crashing when resizing the window

### DIFF
--- a/src/client/Latite.cpp
+++ b/src/client/Latite.cpp
@@ -667,13 +667,12 @@ void Latite::initSettings() {
         set->value = &this->menuBlurEnabled;
         this->getSettings().addSetting(set);
     }
-    /* Removed because of instability
     {
         auto set = std::make_shared<Setting>("useDX11", LocalizeString::get("client.settings.useDX11.name"),
                                              LocalizeString::get("client.settings.useDX11.desc"));
         set->value = &this->useDX11;
         this->getSettings().addSetting(set);
-    }*/
+    }
     {
         auto set = std::make_shared<Setting>("forceDisableVSync", L"Force Disable VSync",
                                              L"Forces VSync in fullscreen. May cause freezing, overheating, and screen tearing on some devices.\nRestart your game upon disabling this setting.");

--- a/src/client/memory/hook/hooks/DXHooks.cpp
+++ b/src/client/memory/hook/hooks/DXHooks.cpp
@@ -19,6 +19,7 @@ namespace {
     bool isForceDisableVSync = false;
     std::shared_ptr<Hook> PresentHook;
     std::shared_ptr<Hook> ResizeBuffersHook;
+    std::shared_ptr<Hook> ResizeBuffers3Hook;
     std::shared_ptr<Hook> ExecuteCommandListsHook;
 
     // TODO: temporary, remove this
@@ -133,6 +134,23 @@ HRESULT __stdcall DXHooks::SwapChain_ResizeBuffers(
     UINT Width,
     UINT Height,
     DXGI_FORMAT NewFormat,
+    UINT SwapChainFlags) {
+    Latite::getRenderer().reinit();
+    UINT newFlags = SwapChainFlags;
+    if (tearingSupported && isForceDisableVSync) {
+        newFlags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+    }
+
+    return ResizeBuffersHook->oFunc<decltype(&SwapChain_ResizeBuffers)>()(
+        chain, BufferCount, Width, Height, NewFormat, newFlags);
+}
+
+HRESULT __stdcall DXHooks::SwapChain3_ResizeBuffers(
+    IDXGISwapChain* chain,
+    UINT BufferCount,
+    UINT Width,
+    UINT Height,
+    DXGI_FORMAT NewFormat,
     UINT SwapChainFlags,
     const UINT *pCreationNodeMask,
     IUnknown *const *ppPresentQueue) {
@@ -143,7 +161,7 @@ HRESULT __stdcall DXHooks::SwapChain_ResizeBuffers(
         newFlags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
     }
 
-    return ResizeBuffersHook->oFunc<decltype(&SwapChain_ResizeBuffers)>()(
+    return ResizeBuffers3Hook->oFunc<decltype(&SwapChain3_ResizeBuffers)>()(
         chain, BufferCount, Width, Height, NewFormat, newFlags, pCreationNodeMask, ppPresentQueue);
 }
 
@@ -235,11 +253,12 @@ DXHooks::DXHooks() : HookGroup("DirectX") {
     }
 
     PresentHook = addHook(vftable[8], SwapChain_Present, "IDXGISwapChain::Present");
-    ResizeBuffersHook = addHook(vftable[39], SwapChain_ResizeBuffers, "IDXGISwapChain3::ResizeBuffers");
+    ResizeBuffersHook = addHook(vftable[13], SwapChain_ResizeBuffers, "IDXGISwapChain::ResizeBuffers");
+    ResizeBuffers3Hook = addHook(vftable[39], SwapChain3_ResizeBuffers, "IDXGISwapChain3::ResizeBuffers");
 
     // Needed for D3D11On12 for DX12
     if (cqueueVftable) ExecuteCommandListsHook = addHook(cqueueVftable[10], CommandQueue_ExecuteCommandLists, "ID3D12CommandQueue::executeCommandLists");
     PresentHook->enable();
-    ResizeBuffersHook->enable();
+    ResizeBuffers3Hook->enable();
     if (cqueueVftable) ExecuteCommandListsHook->enable();
 }

--- a/src/client/memory/hook/hooks/DXHooks.cpp
+++ b/src/client/memory/hook/hooks/DXHooks.cpp
@@ -253,6 +253,8 @@ DXHooks::DXHooks() : HookGroup("DirectX") {
     }
 
     PresentHook = addHook(vftable[8], SwapChain_Present, "IDXGISwapChain::Present");
+
+    // We need both ResizeBuffers hooks as DX11 uses IDXGISwapChain::ResizeBuffers and DX12 uses IDXGISwapChain3::ResizeBuffers
     ResizeBuffersHook = addHook(vftable[13], SwapChain_ResizeBuffers, "IDXGISwapChain::ResizeBuffers");
     ResizeBuffers3Hook = addHook(vftable[39], SwapChain3_ResizeBuffers, "IDXGISwapChain3::ResizeBuffers");
 

--- a/src/client/memory/hook/hooks/DXHooks.h
+++ b/src/client/memory/hook/hooks/DXHooks.h
@@ -6,7 +6,8 @@ class DXHooks : public HookGroup {
 private:
 	static HRESULT WINAPI CreateSwapChainForHWNDHook(IDXGIFactory2* pFactory, IUnknown* pDevice, HWND hwnd, const DXGI_SWAP_CHAIN_DESC1* pDesc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC *pFullscreenDesc, IDXGIOutput* pRestrictToOutput, IDXGISwapChain1** ppSwapChain);
 	static HRESULT __stdcall SwapChain_Present(IDXGISwapChain* chain, UINT SyncInterval, UINT Flags);
-	static HRESULT __stdcall SwapChain_ResizeBuffers(IDXGISwapChain* chain, UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags, const UINT *pCreationNodeMask, IUnknown *const *ppPresentQueue);
+	static HRESULT __stdcall SwapChain_ResizeBuffers(IDXGISwapChain* chain, UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags);
+	static HRESULT __stdcall SwapChain3_ResizeBuffers(IDXGISwapChain* chain, UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags, const UINT *pCreationNodeMask, IUnknown *const *ppPresentQueue);
 	static HRESULT __stdcall CommandQueue_ExecuteCommandLists(ID3D12CommandQueue* queue, UINT NumCommandLists, ID3D12CommandList* const* ppCommandLists);
 
     static void CheckForceDisableVSync();


### PR DESCRIPTION
Fixes crashes when the window is resized in any way (e.g. going fullscreen). Also re-enabled the use DX11 option