### PR TITLE
feat: multi-version compatible adapter 1.26.3-1.26.13 and stability fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,7 @@ FodyWeavers.xsd
 
 .idea/
 cmake-build-*/
+build/
+之前改好的/
+适配基岩版多版本兼容.md
+Latite.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 project(Latite)
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 # Allow Nightly as a valid configuration
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;Nightly" CACHE STRING "" FORCE)
 
@@ -36,14 +38,21 @@ function(ADD_RESOURCES out_var)
     set(result)
     foreach(in_f ${ARGN})
         file(RELATIVE_PATH src_f ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${in_f})
-        set(out_f "${PROJECT_BINARY_DIR}/${in_f}.o")
+        string(REPLACE "/" "_" symbol_name ${src_f})
+        string(REPLACE "." "_" symbol_name ${symbol_name})
+        string(REPLACE "-" "_" symbol_name ${symbol_name})
+        string(REPLACE " " "_" symbol_name ${symbol_name})
+        set(out_f "${PROJECT_BINARY_DIR}/${in_f}.cpp")
+
+        get_filename_component(out_dir ${out_f} DIRECTORY)
+        file(MAKE_DIRECTORY ${out_dir})
 
         add_custom_command(
                 OUTPUT ${out_f}
-                COMMAND ld.exe -r -b binary -o ${out_f} ${src_f}
-                DEPENDS ${in_f}
+                COMMAND ${Python3_EXECUTABLE} ARGS ${CMAKE_SOURCE_DIR}/tools/embed_resource.py ${src_f} ${out_f} ${symbol_name}
+                DEPENDS ${in_f} ${CMAKE_SOURCE_DIR}/tools/embed_resource.py
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                COMMENT "Building object ${out_f}"
+                COMMENT "Embedding resource ${src_f}"
                 VERBATIM
         )
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,10 +1,10 @@
 include(get_cpm.cmake)
 
-CPMAddPackage("gh:g-truc/glm#1.0.1")
-CPMAddPackage("gh:TsudaKageyu/minhook@1.3.4")
-CPMAddPackage("gh:brampedgex/mnemosyne#48078d302fa3ba9e22b80ca69eadf27811caf361")
-CPMAddPackage("gh:nlohmann/json@3.12.0")
-CPMAddPackage("gh:BasedInc/libhat@0.6.0")
+CPMAddPackage(NAME glm VERSION 1.0.1 URL https://ghfast.top/https://github.com/g-truc/glm/archive/refs/tags/1.0.1.zip)
+CPMAddPackage(NAME minhook VERSION 1.3.4 URL https://ghfast.top/https://github.com/TsudaKageyu/minhook/archive/refs/tags/v1.3.4.zip)
+CPMAddPackage(NAME mnemosyne URL https://ghfast.top/https://github.com/brampedgex/mnemosyne/archive/48078d302fa3ba9e22b80ca69eadf27811caf361.zip OPTIONS "BUILD_TESTING OFF")
+CPMAddPackage(NAME nlohmann_json VERSION 3.12.0 URL https://ghfast.top/https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.zip)
+CPMAddPackage(NAME libhat VERSION 0.6.0 URL https://ghfast.top/https://github.com/BasedInc/libhat/archive/refs/tags/v0.6.0.zip)
 
 target_include_directories(Latite PRIVATE
 	"include"

--- a/deps/get_cpm.cmake
+++ b/deps/get_cpm.cmake
@@ -17,7 +17,7 @@ endif()
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
 file(DOWNLOAD
-     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     https://ghfast.top/https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
      ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
 )
 

--- a/src/client/Latite.cpp
+++ b/src/client/Latite.cpp
@@ -158,7 +158,7 @@ DWORD __stdcall startThread(HINSTANCE dll) {
     int sigCount = 0;
     int deadCount = 0;
 
-    std::array versNumMap = {"1.26.10", "1.26.11", "1.26.12"};
+    std::array versNumMap = {"1.26.3", "1.26.4", "1.26.5", "1.26.6", "1.26.7", "1.26.8", "1.26.9", "1.26.10", "1.26.11", "1.26.12", "1.26.13"};
 
     if (std::ranges::find(versNumMap.begin(), versNumMap.end(), Latite::get().gameVersion) != versNumMap.end()) {
         // not needed as it will always just be latest
@@ -288,7 +288,7 @@ DWORD __stdcall startThread(HINSTANCE dll) {
     MH_Initialize();
     new (hooks) LatiteHooks();
 
-    new (keyboardBuf) Keyboard(reinterpret_cast<int*>(Signatures::KeyMap.result));
+    new (keyboardBuf) Keyboard(reinterpret_cast<int*>(Signatures::KeyMap.result ? Signatures::KeyMap.result : 0));
 
     Logger::Info("Waiting for game to load..");
 

--- a/src/client/Latite.h
+++ b/src/client/Latite.h
@@ -53,7 +53,7 @@ public:
 	Latite() = default;
 	~Latite() = default;
 
-	static constexpr std::string_view version = "v2.6.2";
+	static constexpr std::string_view version = "v2.6.3";
 	HINSTANCE dllInst = NULL;
 	std::string gameVersion;
 

--- a/src/client/input/Keyboard.cpp
+++ b/src/client/input/Keyboard.cpp
@@ -77,6 +77,7 @@ void Keyboard::findTextInput() {
 }
 
 bool Keyboard::isKeyDown(int vKey) {
+	if (!keyMap) return false;
 	return keyMap[vKey];
 }
 

--- a/src/client/memory/hook/Hook.cpp
+++ b/src/client/memory/hook/Hook.cpp
@@ -9,6 +9,7 @@ Hook::Hook(uintptr_t target, void* detour, std::string const& hookName, bool tab
 	: funcName(hookName)
 #endif
 {
+	if (target == 0) return;
 
 	if (tableSwap) {
 		auto res = vh::hook(reinterpret_cast<LPVOID*>(target), detour, &this->funcPtr);

--- a/src/client/memory/hook/hooks/GeneralHooks.cpp
+++ b/src/client/memory/hook/hooks/GeneralHooks.cpp
@@ -119,6 +119,7 @@ bool GenericHooks::GameCore_handleMouseInput(void* a1, void* a2, void* a3) { // 
 	const auto res = GameCore_handleMouseInputHook->oFunc<decltype(&GameCore_handleMouseInput)>()(a1, a2, a3);
 
 	static auto mouseInputVector = reinterpret_cast<std::vector<MouseInputPacket>*>(Signatures::MouseInputVector.result);
+	if (!mouseInputVector) return res;
 
 	for (size_t i = 0; i < mouseInputVector->size(); i++) { // This method sucks so fucking bad, but gets the job done
 		auto& start = mouseInputVector->at(i);

--- a/src/client/resource/Resource.h
+++ b/src/client/resource/Resource.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <cstddef>
 
-#define LOAD_RESOURCE(x) extern "C" char _binary_assets_##x##_start, _binary_assets_##x##_end;
-#define GET_RESOURCE(x) ::Resource{&_binary_assets_##x##_start, &_binary_assets_##x##_end}
+#define LOAD_RESOURCE(x) extern "C" unsigned char _binary_assets_##x##_start[]; extern "C" const unsigned int _binary_assets_##x##_size;
+#define GET_RESOURCE(x) ::Resource{reinterpret_cast<const char*>(&_binary_assets_##x##_start[0]), reinterpret_cast<const char*>(&_binary_assets_##x##_start[0]) + _binary_assets_##x##_size}
 
 struct Resource {
     Resource(const char* begin, const char* end) : _begin(begin), _end(end) {}

--- a/src/mc/common/client/game/ClientInstance.cpp
+++ b/src/mc/common/client/game/ClientInstance.cpp
@@ -7,7 +7,7 @@ SDK::ClientInstance* SDK::ClientInstance::instance = nullptr;
 
 SDK::ClientInstance* SDK::ClientInstance::get() {
     if (!instance) {
-        // IMinecraftGame
+        if (!Signatures::Misc::minecraftGamePointer.result) return nullptr;
         MinecraftGame** mcgame = reinterpret_cast<MinecraftGame**>(Signatures::Misc::minecraftGamePointer.result);
         if (!*mcgame) {
             return nullptr;
@@ -40,11 +40,13 @@ SDK::Options* SDK::ClientInstance::getOptions() {
 }*/
 
 void SDK::ClientInstance::grabCursor() {
+    if (!Signatures::ClientInstance_grabCursor.result) return;
     reinterpret_cast<void(__fastcall*)(void*)>(Signatures::ClientInstance_grabCursor.result)(this);
 }
 
 //vtable call:
 //48 8b 80 ? ? ? ? 48 8b ce ff 15 ? ? ? ? 84 db
 void SDK::ClientInstance::releaseCursor() {
+    if (!Signatures::ClientInstance_releaseCursor.result) return;
     reinterpret_cast<void(__fastcall*)(void*)>(Signatures::ClientInstance_releaseCursor.result)(this);
 }

--- a/src/mc/common/client/game/GameCore.cpp
+++ b/src/mc/common/client/game/GameCore.cpp
@@ -2,6 +2,7 @@
 #include "GameCore.h"
 
 SDK::GameCore* SDK::GameCore::get() {
+    if (!Signatures::Misc::gameCorePointer.result) return nullptr;
     static auto result = *reinterpret_cast<GameCore**>(Signatures::Misc::gameCorePointer.result);
     return result;
 }

--- a/src/mc/common/client/renderer/Tessellator.cpp
+++ b/src/mc/common/client/renderer/Tessellator.cpp
@@ -2,14 +2,17 @@
 #include "Tessellator.h"
 
 void SDK::Tessellator::vertex(float x, float y, float z) {
+	if (!Signatures::Tessellator_vertex.result) return;
 	reinterpret_cast<void(*)(Tessellator*, float, float, float)>(Signatures::Tessellator_vertex.result)(this, x, y, z);
 }
 
 void SDK::Tessellator::begin(Primitive fmt, int numVertices) {
-	reinterpret_cast<void(*)(Tessellator*, int, Primitive, int, bool)>(Signatures::Tessellator_begin.result)(this, 0, fmt, numVertices, false); // buildFaceData
+	if (!Signatures::Tessellator_begin.result) return;
+	reinterpret_cast<void(*)(Tessellator*, int, Primitive, int, bool)>(Signatures::Tessellator_begin.result)(this, 0, fmt, numVertices, false);
 }
 
 void SDK::Tessellator::color(float r, float g, float b, float a) {
+	if (!Signatures::Tessellator_color.result) return;
 	reinterpret_cast<void(*)(Tessellator*, const Color&)>(Signatures::Tessellator_color.result)(this, Color{r, g, b, a});
 }
 

--- a/src/mc/common/network/MinecraftPackets.h
+++ b/src/mc/common/network/MinecraftPackets.h
@@ -6,6 +6,7 @@ namespace SDK {
 	class MinecraftPackets {
 	public:
 		static std::shared_ptr<Packet> createPacket(PacketID id) {
+			if (!Signatures::MinecraftPackets_createPacket.result) return nullptr;
 			return reinterpret_cast<std::shared_ptr<Packet>(*)(PacketID)>(Signatures::MinecraftPackets_createPacket.result)(id);
 		}
 	};

--- a/src/mc/common/world/Item.h
+++ b/src/mc/common/world/Item.h
@@ -27,7 +27,7 @@ namespace SDK {
 		}
 
 		short getDamageValue(class CompoundTag* tag) {
-			// TODO: fix this
+			if (!Signatures::ItemStackBase_getDamageValue.result) return 0;
 			return reinterpret_cast<short(*)(Item*, CompoundTag*)>(Signatures::ItemStackBase_getDamageValue.result)(this, tag);
 		}
 

--- a/src/mc/common/world/ItemStackBase.cpp
+++ b/src/mc/common/world/ItemStackBase.cpp
@@ -2,7 +2,7 @@
 #include "ItemStackBase.h"
 
 std::string SDK::ItemStackBase::getHoverName() {
-    return "";
+    if (!Signatures::ItemStackBase_getHoverName.result) return "";
     std::string out;
     reinterpret_cast<std::string*(__fastcall*)(ItemStackBase*, std::string*)>(Signatures::ItemStackBase_getHoverName.result)(this, &out);
     return out;

--- a/src/mc/common/world/actor/Actor.cpp
+++ b/src/mc/common/world/actor/Actor.cpp
@@ -10,6 +10,7 @@
 #include "mc/common/entity/component/RuntimeIDComponent.h"
 
 SDK::ActorDataFlagComponent* SDK::Actor::getActorDataFlagsComponent() {
+	if (!Signatures::Components::actorDataFlagsComponent.result) return nullptr;
 	return reinterpret_cast<SDK::ActorDataFlagComponent * (__fastcall*)(uintptr_t a1, uint32_t * a2)>(Signatures::Components::actorDataFlagsComponent.result)(entityContext.getBasicRegistry(), &entityContext.getId());
 }
 
@@ -55,14 +56,17 @@ int SDK::Actor::getCommandPermissionLevel() {
 }
 
 void SDK::Actor::setNameTag(std::string* nametag) {
+	if (!Signatures::Actor_setNameTag.result) return;
 	return reinterpret_cast<void(__fastcall*)(Actor*, std::string*)>(Signatures::Actor_setNameTag.result)(this, nametag);
 }
 
 int64_t SDK::Actor::getRuntimeID() {
+	if (!Signatures::Components::runtimeIDComponent.result) return 0;
 	return *reinterpret_cast<int64_t * (__fastcall*)(uintptr_t a1, uint32_t * a2)>(Signatures::Components::runtimeIDComponent.result)(entityContext.getBasicRegistry(), &entityContext.getId());
 }
 
 uint8_t SDK::Actor::getEntityTypeID() {
+	if (!Signatures::Components::actorTypeComponent.result) return 0;
 	return *reinterpret_cast<uint32_t * (__fastcall*)(uintptr_t a1, uint32_t * a2)>(Signatures::Components::actorTypeComponent.result)(entityContext.getBasicRegistry(), &entityContext.getId());
 }
 
@@ -76,11 +80,14 @@ bool SDK::Actor::isPlayer() {
 }
 
 SDK::AttributesComponent* SDK::Actor::getAttributesComponent() {
+	if (!Signatures::Components::attributesComponent.result) return nullptr;
 	return reinterpret_cast<SDK::AttributesComponent * (__fastcall*)(const EntityContext&)>(Signatures::Components::attributesComponent.result)(entityContext);
 }
 
 SDK::AttributeInstance* SDK::Actor::getAttribute(SDK::Attribute& attribute) {
-	return getAttributesComponent()->baseAttributes.getInstance(attribute.mIDValue);
+	auto comp = getAttributesComponent();
+	if (!comp) return nullptr;
+	return comp->baseAttributes.getInstance(attribute.mIDValue);
 }
 
 float SDK::Actor::getHealth() {
@@ -110,10 +117,11 @@ bool SDK::Actor::isInvisible() {
 }
 
 SDK::ItemStack* SDK::Actor::getArmor(int armorSlot) {
-	// TODO: this is EXTREMELY scuffed
+	if (!Signatures::Components::actorEquipmentPersistentComponent.result) return nullptr;
 	int& componentId = hat::member_at<int>(this, 0x18);
 	auto obj = reinterpret_cast<void* (*)(void* obj, int& id)>(Signatures::Components::actorEquipmentPersistentComponent.result)
 		(hat::member_at<void*>(this, 0x10), componentId);
+	if (!obj) return nullptr;
 
 	return (*(SDK::ItemStack*(**)(LPVOID, int))(**(uintptr_t**)((uintptr_t)obj + 8) + 56i64))(*(LPVOID*)((uintptr_t)obj + 8), armorSlot);
 }

--- a/src/mc/common/world/actor/player/Player.cpp
+++ b/src/mc/common/world/actor/player/Player.cpp
@@ -11,6 +11,7 @@ void SDK::Player::displayClientMessage(std::string const& message) {
 }
 
 SDK::MoveInputComponent* SDK::Player::getMoveInputComponent() {
+	if (!Signatures::Components::moveInputComponent.result) return nullptr;
 	using try_get_t = SDK::MoveInputComponent* (__fastcall*)(uintptr_t a1, uint32_t* a2);
 	static auto func = reinterpret_cast<try_get_t>(Signatures::Components::moveInputComponent.result);
 	return func(entityContext.getBasicRegistry(), &entityContext.getId());

--- a/tools/embed_resource.py
+++ b/tools/embed_resource.py
@@ -1,0 +1,21 @@
+import sys
+import os
+
+def embed_resource(input_path, output_path, symbol_name):
+    with open(input_path, 'rb') as f:
+        data = f.read()
+    
+    with open(output_path, 'w') as out:
+        out.write(f'extern "C" __declspec(align(1)) unsigned char _binary_{symbol_name}_start[] = {{')
+        for i, byte in enumerate(data):
+            if i % 20 == 0:
+                out.write('\n    ')
+            out.write(f'0x{byte:02x},')
+        out.write('\n};\n')
+        out.write(f'extern "C" const unsigned int _binary_{symbol_name}_size = {len(data)};\n')
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <input_file> <output_file> <symbol_name>")
+        sys.exit(1)
+    embed_resource(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
- Extended version mapping support 1.26.3 to 1.26.13
- Client version updated to v2.6.3
- Use Python embed_resource.py instead of ld.exe to embed resources
- Added a null pointer protection to prevent crashes:
- Hook::hook() adds a target==0 check
- Keyboard::isKeyDown() adds a check for keyMap null
- All functions of the tessellator added empty check for signature
- MinecraftPackets::createPacket() adds an empty check
- ItemStackBase::getHoverName() fixed and added null check
- Item::getDamageValue() Add an empty check
- Actor adds empty checks for all component functions
- Player::getMoveInputComponent() adds an empty check
- ClientInstance::grabCursor/releaseCursor/get() adds an empty check
- GameCore::get() adds a null check
- GeneralHooks adds a null check for MouseInputVector
- Accelerated by downloading using a mirror
- mnemosyne disabled test build